### PR TITLE
Update d_main.c

### DIFF
--- a/d_main.c
+++ b/d_main.c
@@ -1042,8 +1042,8 @@ void IdentifyVersionAndSelect (void)        // cosmito
     char *doomwaddir;
 	
 #ifdef _EE
-    extern char elfFilename[100];
-    extern char deviceName[10];
+//  extern char elfFilename[100];
+//  extern char deviceName[10];
     extern char fullPath[256];
 #endif
 

--- a/d_main.c
+++ b/d_main.c
@@ -1042,8 +1042,6 @@ void IdentifyVersionAndSelect (void)        // cosmito
     char *doomwaddir;
 	
 #ifdef _EE
-//  extern char elfFilename[100];
-//  extern char deviceName[10];
     extern char fullPath[256];
 #endif
 


### PR DESCRIPTION
Fix compiler warning:
d_main.c:1045: warning: unused variable `elfFilename'
d_main.c:1046: warning: unused variable `deviceName'