### PR TITLE
Update am_map.c

### DIFF
--- a/am_map.c
+++ b/am_map.c
@@ -616,7 +616,6 @@ AM_Responder
 {
 
     int rc;
-    static int cheatstate=0;
     static int bigstate=0;
     static char buffer[20];
 


### PR DESCRIPTION
Fix:
am_map.c: Na função ‘AM_Responder’:
am_map.c:619:16: aviso: variable ‘cheatstate’ set but not used [-Wunused-but-set-variable]