### PR TITLE
Update hu_lib.c

### DIFF
--- a/hu_lib.c
+++ b/hu_lib.c
@@ -146,8 +146,7 @@ void HUlib_eraseTextLine(hu_textline_t* l)
     int			lh;
     int			y;
     int			yoffset;
-    static boolean	lastautomapactive = true;
-
+    
     // Only erases when NOT in automap and the screen is reduced,
     // and the text must either need updating or refreshing
     // (because of a recent change back from the automap)


### PR DESCRIPTION
Fix:
hu_lib.c:149:25: aviso: variable ‘lastautomapactive’ set but not used [-Wunused-but-set-variable]
  149 |     static boolean      lastautomapactive = true;