### PR TITLE
Update d_main.c

### DIFF
--- a/d_main.c
+++ b/d_main.c
@@ -33,6 +33,7 @@ static const char rcsid[] = "$Id: d_main.c,v 1.8 1997/02/03 22:45:09 b1 Exp $";
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <kernel.h>
 
 /// cosmito
 static char padBuf[256] __attribute__((aligned(64)));


### PR DESCRIPTION
The "#include <kernel.h>" line is required to fix the following errors during compiling:

d_main.c:899:49: erro: unknown type name ‘u32’
d_main.c:899:62: erro: unknown type name ‘u32’
d_main.c:912:45: erro: unknown type name ‘u32’
d_main.c:912:58: erro: unknown type name ‘u32’
d_main.c:1195:9: erro: unknown type name ‘u32’
d_main.c:1196:9: erro: unknown type name ‘u32’