### PR TITLE
Update s_sound.c

### DIFF
--- a/s_sound.c
+++ b/s_sound.c
@@ -215,7 +215,7 @@ void S_Start(void)
 			else
 				mnum = spmus[gamemap-1];
 		}
-		S_ChangeMusic(mnum, true);
+	S_ChangeMusic(mnum, true);
 }
 
 void S_StartSoundAtVolume(void *origin_p, int sfx_id, int volume)


### PR DESCRIPTION
Removing this TAB on the line avoids the following warning when compiling:

s_sound.c: Na função ‘S_Start’:
s_sound.c:195:9: aviso: this ‘else’ clause does not guard... [-Wmisleading-indentation]
  195 |         else
      |         ^~~~
s_sound.c:218:17: nota: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
  218 |                 S_ChangeMusic(mnum, true);
      |                 ^~~~~~~~~~~~~