### PR TITLE
Update mmus2mid.c

### DIFF
--- a/mmus2mid.c
+++ b/mmus2mid.c
@@ -542,7 +542,7 @@ int mmus2mid(const UBYTE *mus, MIDI *mididata, UWORD division, int nocomp)
 			mididata->track[i].data = NULL;
 		}
 
-		return 0;
+	return 0;
 }
 
 void free_mididata(MIDI *mid)
@@ -635,7 +635,7 @@ int MidiToMIDI(UBYTE *mid,MIDI *mididata)
 			mididata->track[i].data = NULL;
 			mididata->track[i].len = 0;
 		}
-		return 0;
+	return 0;
 }
 
 //#ifdef STANDALONE /* this code unused by BOOM provided for future portability */


### PR DESCRIPTION
Fix the following compiler warnings:

mmus2mid.c: Na função ‘mmus2mid’:
mmus2mid.c:524:9: aviso: this ‘for’ clause does not guard... [-Wmisleading-indentation]
  524 |         for (i = 0; i < MIDI_TRACKS; i++)
      |         ^~~
mmus2mid.c:545:17: nota: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
  545 |                 return 0;
      |                 ^~~~~~




mmus2mid.c: Na função ‘MidiToMIDI’:
mmus2mid.c:631:9: aviso: this ‘for’ clause does not guard... [-Wmisleading-indentation]
  631 |         for (;i<MIDI_TRACKS;i++)
      |         ^~~
mmus2mid.c:638:17: nota: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
  638 |                 return 0;
      |                 ^~~~~~